### PR TITLE
fix(spec): autoIncrement should require unique or primaryKey

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,10 +269,26 @@ var PgDriver = Base.extend({
         var constraint = [],
             cb;
 
+        if ((spec.unique || spec.primaryKey) && spec.autoIncrement) {
+          switch (spec.dataType) {
+                case type.BIGINT:
+                    constraint.push('BIGSERIAL');                    
+                    break;
+                case type.SMALLINT:
+                    constraint.push('SMALLSERIAL');
+                    break;
+                default:
+                    constraint.push('SERIAL');
+                    break;
+            }          
+        }
+        else {
+          if (spec.autoIncrement) {
+            throw 'Auto increment column must be unique or primary key';
+          }
+        }
+
         if (spec.primaryKey && options.emitPrimaryKey) {
-            if (spec.autoIncrement) {
-                constraint.push('SERIAL');
-            }
             constraint.push('PRIMARY KEY');
         }
 


### PR DESCRIPTION
- fixes autoIncrement producing broken sql when used with unique but not primary key
- add support for smallint to map to SMALLSERIAL and bigint to map to BIGSERIAL
- throws error when autoIncrement is specified without unique or primary key