### PR TITLE
fix(docs): added example npm install to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,9 @@
 
 # pg
 postgres driver for db-migrate
+
+## Installation
+
+```
+npm install db-migrate-pg
+```


### PR DESCRIPTION
makes the npm package name easy to see

Because opening package.json and reading it is so hard :)