### PR TITLE
add more column specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ postgres driver for db-migrate
 ## Installation
 
 ```
-npm install db-migrate-pg
+npm install --save db-migrate-pg
 ```

--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ var PgDriver = Base.extend({
         }
 
         return { foreignKey: constraint.foreignKey,
+                 callbacks: constraint.callbacks,
                  constraints: [name, type, len, constraint.constraints].join(' ') };
     },
 
@@ -276,6 +277,7 @@ var PgDriver = Base.extend({
 
     createColumnConstraint: function(spec, options, tableName, columnName) {
         var constraint = [],
+            callbacks = [],
             cb;
 
         if (spec.primaryKey && options.emitPrimaryKey) {
@@ -306,12 +308,20 @@ var PgDriver = Base.extend({
             }
         }
 
+        // keep foreignKey for backward compatiable, push to callbacks in the future
         if (spec.foreignKey) {
 
           cb = this.bindForeignKey(tableName, columnName, spec.foreignKey);
         }
+        if (spec.comment) {
+          // TODO: create a new function addComment is not callable from here
+          callbacks.push((function(tableName, columnName, comment, callback) {
+            var sql = util.format("COMMENT on COLUMN %s.%s IS '%s'", tableName, columnName, comment)
+            return this.runSql(sql).nodeify(callback)
+          }).bind(this, tableName, columnName, spec.comment))
+        }
 
-        return { foreignKey: cb, constraints: constraint.join(' ') };
+        return { foreignKey: cb, callbacks: callbacks, constraints: constraint.join(' ') };
     },
 
     renameTable: function(tableName, newTableName, callback) {

--- a/test/pg_test.js
+++ b/test/pg_test.js
@@ -47,6 +47,7 @@ vows.describe('pg').addBatch({
         smalint: dataType.SMALLINT,
         dt: dataType.DATE,
         dti: dataType.DATE_TIME,
+        dti_tz: { type: dataType.DATE_TIME, timezone: true },
         bl: dataType.BOOLEAN
       }, this.callback.bind(this));
     },
@@ -77,9 +78,9 @@ vows.describe('pg').addBatch({
         }.bind(this));
       },
 
-      'with 10 columns': function(err, columns) {
+      'with 11 columns': function(err, columns) {
         assert.isNotNull(columns);
-        assert.equal(columns.length, 10);
+        assert.equal(columns.length, 11);
       },
 
       'that has integer id column that is primary key, non-nullable, and auto increments': function(err, columns) {
@@ -124,6 +125,12 @@ vows.describe('pg').addBatch({
       'that has integer dti column': function(err, columns) {
         var column = findByName(columns, 'dti');
         assert.equal(column.getDataType(), 'TIMESTAMP WITHOUT TIME ZONE');
+        assert.equal(column.isNullable(), true);
+      },
+
+      'that has timestamp with time zone column': function(err, columns) {
+        var column = findByName(columns, 'dti_tz');
+        assert.equal(column.getDataType(), 'TIMESTAMP WITH TIME ZONE');
         assert.equal(column.isNullable(), true);
       },
 


### PR DESCRIPTION
* add option `timezone` for  datatype `timestamp` and `time`
* add datatype json & jsonb (disable warning)
* add option comment(work with db-migrate/db-migrate-base#6 which exec extra callbacks after create table)