### PR TITLE
handle 10.1 version

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,15 +162,15 @@ var PgDriver = Base.extend({
         ifNotExists: false
       };
 
-      return this.all('select version() as version')
+      return this.all('show server_version')
       .then(function(result) {
 
-        if (result && result && result.length > 0 && result[0].version) {
-          var version = result[0].version;
-          var match = version.match(/\d+\.\d+\.\d+/);
-          if (match && match[0] && semver.gte(match[0], '9.1.0')) {
-            options.ifNotExists = true;
+        if (result && result && result.length > 0 && result[0].server_version) {
+          var version = result[0].server_version;
+          if(version.split('.').length !== 3){
+            version += '.0';
           }
+          options.ifNotExists = semver.gte(version, '9.1.0');
         }
 
         // Get the current search path so we can change the current schema


### PR DESCRIPTION
When running db-migrate against postgreSQL running in a docker container I noticed that running migrations twice would fail on an error saying that the migration table already exists.  

This is because the regex that was being used to determine the version was incorrectly grabbing a different semver from the string returned by the query.  This is in part to postgreSQL 10.1 not including the patch number with it's version.

In my case the string returned was `PostgreSQL 10.1 on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18) 6.3.0 20170516, 64-bit`

When running on osx the string returned from the query was `PostgreSQL 10.1 on x86_64-apple-darwin17.2.0, compiled by Apple LLVM version 9.0.0 (clang-900.0.38), 64-bit`.  The match however succeeded because the regex matched on the darwin version 17.2.0 NOT the postgreSQL version.  

I replaced the query with `show server_version` which returns just the semver.

