### PR TITLE
fix(addForeignKey): pass joined strings to `util.format`

### DIFF
--- a/index.js
+++ b/index.js
@@ -543,9 +543,9 @@ var PgDriver = Base.extend({
       'ALTER TABLE "%s" ADD CONSTRAINT "%s" FOREIGN KEY (%s) REFERENCES "%s" (%s) ON DELETE %s ON UPDATE %s',
       tableName,
       keyName,
-      this.quoteDDLArr(columns),
+      this.quoteDDLArr(columns).join(', '),
       referencedTableName,
-      referencedColumns,
+      referencedColumns.join(', '),
       rules.onDelete || 'NO ACTION',
       rules.onUpdate || 'NO ACTION'
     );


### PR DESCRIPTION
node v12 seems to no longer format arrays passed as strings by
`.toString()`ing them, which effectively resulted in a `.join(',')`, but
returning in something to the tune of:

```
> util.format('%s', ['foo','bar'])
"[ 'foo', 'bar' ]"
```

While v11.15.0 returns:
```
> util.format('%s', ['foo','bar'])
'foo,bar'
```

This fixes this issue on v12, and doesn't break any other version.

Shall we add v10, v11 and v12 to `.travis.yml`?