### PR TITLE
Fix bug where already-quoted search path components could get double-quoted when creating the migrations table.

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ var PgDriver = Base.extend({
           var searchPathes = result[0].search_path.split(',');
 
           for (var i = 0; i < searchPathes.length; ++i) {
-            if (searchPathes[i].indexOf('"') !== 0) {
+            if (searchPathes[i].indexOf('"') !== -1) {
               searchPathes[i] = '"' + searchPathes[i].trim() + '"';
             }
           }


### PR DESCRIPTION
Postgres's `SHOW search_path` returns the search path as a comma-separated string with spaces, like `"$user", public, "another-quoted-schema"`, so checking whether the _first character_ of a search path component is `"` is not sufficient. Instead, just check whether the search path component contains quotes at all, and don't add any quotes if it does.

To reproduce the bug:
- Run:
    ```sql
   ALTER ROLE <username> SET search_path TO "$user",public,"something-with-quotes";
    ```
- Apply migrations
- db-migrate-pg tries to run something like this (note the `""`):
    ```sql
    SET search_path TO "$user","public",""something-with-quotes""
   ```
- Get an error like:
    ```
    [ERROR] error: zero-length delimited identifier at or near """"
        at Connection.parseE (/Users/griffinschneider/dev/core/node_modules/pg/lib/connection.js:604:13)
        at Connection.parseMessage (/Users/griffinschneider/dev/core/node_modules/pg/lib/connection.js:403:19)
        at Socket.<anonymous> (/Users/griffinschneider/dev/core/node_modules/pg/lib/connection.js:123:22)
        at Socket.emit (events.js:305:20)
        at Socket.EventEmitter.emit (domain.js:483:12)
        at addChunk (_stream_readable.js:341:12)
        at readableAddChunk (_stream_readable.js:316:11)
        at Socket.Readable.push (_stream_readable.js:250:10)
        at TCP.onStreamRead (internal/stream_base_commons.js:186:23)
    ```