### PR TITLE
fix(travis): add postgresql service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,9 @@ cache:
   directories:
     - node_modules
 
+services:
+  - postgresql
+
 addons:
   apt:
     sources:


### PR DESCRIPTION
Currently travis-ci doesn't starts postgresql, because postgresql  service not defined.