### PR TITLE
(Issue#45) Scope Configuration doesn't work with Postgres

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,15 +129,17 @@ var PgDriver = Base.extend({
     if (typeof options === 'object') {
       if (typeof options.database === 'string') {
         this.log.info(
-          'Ignore database option, not available with postgres. Use schema instead!'
+            'Ignore database option, not available with postgres. Use schema instead!'
         );
+      }
+      if (typeof options.schema === 'string') {
         this.runSql(
-          util.format('SET search_path TO `%s`', options.database),
+          util.format('SET search_path TO %s,%s', options.schema, this.schema),
           callback
         );
       }
     } else if (typeof options === 'string') {
-      this.runSql(util.format('SET search_path TO `%s`', options), callback);
+      this.runSql(util.format('SET search_path TO %s,%s', options, this.schema), callback);
     } else callback(null);
   },
 


### PR DESCRIPTION
Hi,
I noticed same issue described by @Manny651 when tried using scope config.json as described in issue #45 . The problem is that 'database' property attempted to use as a schema despite of warning message that it is going to be ignored, and 'schema' property ignored at the same time. More importantly, SET search_path TO `databaseName` statement contains tildas which is not correct postgres syntax.
The change am I proposing is:

1. Fix SET search_path TO schema syntax 
2. Use 'schema' property instead of 'database' inside switchDatabase method.
3. When switching db, preserve original schema in search path so migrations table is still available
Please approve PR.