### PR TITLE
fix: Add check for rules object

### DIFF
--- a/index.js
+++ b/index.js
@@ -568,8 +568,8 @@ var PgDriver = Base.extend({
       this.quoteDDLArr(columns).join(', '),
       referencedTableName,
       referencedColumns.join(', '),
-      rules.onDelete || 'NO ACTION',
-      rules.onUpdate || 'NO ACTION'
+      (rules && rules.onDelete) || 'NO ACTION',
+      (rules && rules.onUpdate) || 'NO ACTION'
     );
     return this.runSql(sql).nodeify(callback);
   },


### PR DESCRIPTION
This fixes https://github.com/db-migrate/pg/issues/37 where you get an error:

`cannot read property OnDelete of undefined` when you don't pass a rules object to the `foreignKey`. I tried to add a test for this that would just pass an empty config, but was stuck trying to get the tests running successfully on my machine (Windows 10)