### PR TITLE
Add UUID type

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ var PgDriver = Base.extend({
         return 'TIMESTAMP';
       case this.type.BLOB:
         return 'BYTEA';
+      case this.type.UUID:
+        return 'uuid';
     }
     return this._super(str);
   },


### PR DESCRIPTION
This depends on the `uuid-ossp` extension, so it can be questionable, but the purpose behind it is to eliminate the "false" warning messages.

<img width="309" alt="Screenshot 2022-05-29 at 19 12 36" src="https://user-images.githubusercontent.com/4337769/170882859-802b5bf0-22b5-44c9-a37a-3e10951848d2.png">

