### PR TITLE
fix(switchDatabase): scope configuration not working with schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,12 +132,18 @@ var PgDriver = Base.extend({
           'Ignore database option, not available with postgres. Use schema instead!'
         );
         this.runSql(
-          util.format('SET search_path TO `%s`', options.database),
+          util.format('SET search_path TO %s', options.database),
+          callback
+        );
+      } else if (typeof options.schema === 'string') {
+        this.schema = options.schema
+        this.runSql(
+          util.format('SET search_path TO %s', options.schema),
           callback
         );
       }
     } else if (typeof options === 'string') {
-      this.runSql(util.format('SET search_path TO `%s`', options), callback);
+      this.runSql(util.format('SET search_path TO %s', options), callback);
     } else callback(null);
   },
 

--- a/test/pg_test.js
+++ b/test/pg_test.js
@@ -1157,6 +1157,32 @@ vows
       }
     }
   })
+  .addBatch({
+    switchDatabase: {
+      topic: function () {
+        db.switchDatabase({ schema: 'test_schema2' }, this.callback);
+      },
+
+      'has search path': {
+        topic: function () {
+          db.runSql('SHOW search_path', this.callback);
+        },
+
+        'containing the new schema': function (err, result) {
+          assert.isNull(err);
+          var rows = result.rows;
+          assert.isNotNull(rows);
+          assert.strictEqual(rows.length, 1);
+          var row = rows[0];
+          assert.strictEqual(row.search_path, 'test_schema2');
+        }
+      },
+
+      teardown: function () {
+        db.switchDatabase({ schema: config.schema }, this.callback);
+      }
+    }
+  })
   .export(module);
 
 function findByName (columns, name) {


### PR DESCRIPTION
I noticed the same issue reported in https://github.com/db-migrate/pg/issues/45, and it looks like a [potential fix](https://github.com/db-migrate/pg/pull/54) was abandoned, so this is a new proposal to fix the scoping issue:

- Remove backticks when setting the `search_path`.
- Support the `schema` property specified in the config.json file.
- Update the internal `schema` property to avoid resetting the `search_path` and have a migrations table created for each schema.